### PR TITLE
workaround missing https: allow http port overrides instead of using ports from upstream

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,9 @@ http {
             http_req = "GET /status HTTP/1.0\\r\\nHost: foo.com\\r\\n\\r\\n",
                     -- raw HTTP request for checking
 
+            -- you can override any port from upstream by this one
+            -- http_port = 80,
+
             interval = 2000,  -- run the check cycle every 2 sec
             timeout = 1000,   -- 1 sec is the timeout for network operations
             fall = 3,  -- # of successive failures before turning a peer down

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -519,6 +519,10 @@ function _M.spawn_checker(opts)
         return nil, "\"http_req\" option required"
     end
 
+    -- this field is OPTIONal: (80 by default)
+    -- used to override upstream ports used for healthchecking
+    local http_port = opts.http_port
+
     local timeout = opts.timeout
     if not timeout then
         timeout = 1000
@@ -601,6 +605,16 @@ function _M.spawn_checker(opts)
         version = 0,
         concurrency = concur,
     }
+
+    -- as far as we do not support https override ports if set
+    if http_port then
+        for i, _ in ipairs(ctx.primary_peers) do
+            ctx.primary_peers[i].port = http_port
+        end
+        for i, peer in ipairs(ctx.backup_peers) do
+            ctx.backup_peers[i].port = http_port
+        end
+    end
 
     local ok, err = new_timer(0, check, ctx)
     if not ok then


### PR DESCRIPTION
This introduces new `http_port` context variable to allow workaround an issue of:

- missing https support
- the cases in which ports where /Status is exposed do not match to the server group ports set read from upstream.

Example:

        upstream backend {
            server primary:443;
            server secondary:443 backup;
            server slave:443 backup;
        }

        # but i want to healthcheck it, so i expose /Status at :80

        lua_shared_dict healthcheck 10m;

        init_worker_by_lua '
            local hc = require "resty.upstream.healthcheck"

            local ok, err = hc.spawn_checker{
                shm = "healthcheck", 
                upstream = "backend",

                type = "http",
                http_req = "GET /status HTTP/1.0\\r\\n\\r\\n",
                http_port = 80
            }

            if not ok then
                ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
                return
            end
        ';