### PR TITLE
add ssl support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,9 @@ http {
             http_req = "GET /status HTTP/1.0\\r\\nHost: foo.com\\r\\n\\r\\n",
                     -- raw HTTP request for checking
 
+            ssl = false, -- use https
+            ssl_verify = true, -- verify SSL certs, see https://github.com/openresty/lua-nginx-module/pull/290
+
             interval = 2000,  -- run the check cycle every 2 sec
             timeout = 1000,   -- 1 sec is the timeout for network operations
             fall = 3,  -- # of successive failures before turning a peer down


### PR DESCRIPTION
I have added ssl handshake if requested to support https during health checking. It also able to skip cert checks which is fine for my use case. Session caching could be added in the future.

        local ok, err = hc.spawn_checker{
            shm = "healthcheck",  -- defined by "lua_shared_dict"
            upstream = "foo.com", -- defined by "upstream"
            type = "http",

            -- if you put this Lua snippet in separate .lua file,
            -- then you should write this instead: http_req = "GET /status HTTP/1.0\r\nHost: foo.com\r\n\r\n",
            http_req = "GET /status HTTP/1.0\\r\\nHost: foo.com\\r\\n\\r\\n",
                    -- raw HTTP request for checking

            ssl = true, -- use https
            ssl_verify = false, -- verify SSL certs, see https://github.com/openresty/lua-nginx-module/pull/290

            interval = 2000,  -- run the check cycle every 2 sec
            timeout = 1000,   -- 1 sec is the timeout for network operations
            fall = 3,  -- # of successive failures before turning a peer down
            rise = 2,  -- # of successive successes before turning a peer up
            valid_statuses = {200, 302},  -- a list valid HTTP status code
            concurrency = 10,  -- concurrency level for test requests
        }