### PR TITLE
Added tostring and pcall to locals.

### DIFF
--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -13,11 +13,13 @@ local debug_mode = ngx.config.debug
 local worker_pid = ngx.worker.pid
 local concat = table.concat
 local tonumber = tonumber
+local tostring = tostring
 local ipairs = ipairs
 local ceil = math.ceil
 local fmod = math.fmod
 local spawn = ngx.thread.spawn
 local wait = ngx.thread.wait
+local pcall = pcall
 
 local _M = {
     _VERSION = '0.03'


### PR DESCRIPTION
Here is the last one. Well, at least I care about the tiny details ;-). Other than than, in my personal review round on OpenResty Core libs I didn't find anything alarming on them.