### PR TITLE
ipv6 address support in upstream peer name

### DIFF
--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -4,6 +4,7 @@ local ERR = ngx.ERR
 local INFO = ngx.INFO
 local WARN = ngx.WARN
 local DEBUG = ngx.DEBUG
+local str_find = string.find
 local sub = string.sub
 local re_find = ngx.re.find
 local new_timer = ngx.timer.at
@@ -511,9 +512,12 @@ local function preprocess_peers(peers)
     for i = 1, n do
         local p = peers[i]
         local name = p.name
+
         if name then
-            if name:sub(-1, -1)~=']' then
-                p.host, p.port = name:match'(.*):(.*)'
+            local from, to, err = re_find(name, [[^(.*):\d+$]], "jo", nil, 1)
+            if from then
+                p.host = sub(name, 1, to)
+                p.port = tonumber(sub(name, to + 2))
             end
         end
     end

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -4,7 +4,6 @@ local ERR = ngx.ERR
 local INFO = ngx.INFO
 local WARN = ngx.WARN
 local DEBUG = ngx.DEBUG
-local str_find = string.find
 local sub = string.sub
 local re_find = ngx.re.find
 local new_timer = ngx.timer.at
@@ -513,10 +512,8 @@ local function preprocess_peers(peers)
         local p = peers[i]
         local name = p.name
         if name then
-            local idx = str_find(name, ":", 1, true)
-            if idx then
-                p.host = sub(name, 1, idx - 1)
-                p.port = tonumber(sub(name, idx + 1))
+            if name:sub(-1, -1)~=']' then
+                p.host, p.port = name:match'(.*):(.*)'
             end
         end
     end

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -9,7 +9,7 @@ use Cwd qw(cwd);
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6 + 7);
+plan tests => repeat_each() * (blocks() * 6 + 9);
 
 my $pwd = cwd();
 
@@ -815,7 +815,7 @@ init_worker_by_lua '
         shm = "healthcheck",
         upstream = "foo.com",
         type = "http",
-        http_req = "GET /status HTTP/1.0\\\\r\\\\nHost: localhost\\\\r\\\\n\\\\r\\\\n",
+        http_req = "GET /status HTTP/1.0\r\nHost: localhost\r\n\r\n",
         interval = 100,  -- 100ms
         fall = 2,
     }
@@ -823,12 +823,12 @@ init_worker_by_lua '
         ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
         return
     end
-';
+}
 }
 --- config
     location = /t {
         access_log off;
-        content_by_lua '
+        content_by_lua_block {
             ngx.sleep(0.52)
 
             local hc = require "resty.upstream.healthcheck"
@@ -1025,7 +1025,7 @@ server {
 }
 
 lua_shared_dict healthcheck 1m;
-init_worker_by_lua '
+init_worker_by_lua_block {
     ngx.shared.healthcheck:flush_all()
     local hc = require "resty.upstream.healthcheck"
     local ok, err = hc.spawn_checker{
@@ -1241,14 +1241,14 @@ init_worker_by_lua_block {
                 local res = ngx.location.capture("/proxy")
                 ngx.say("upstream addr: ", res.header["X-Foo"])
             end
-        ';
+        }
     }
 
     location = /proxy {
         proxy_pass http://foo.com/;
-        header_filter_by_lua '
+        header_filter_by_lua_block {
             ngx.header["X-Foo"] = ngx.var.upstream_addr;
-        ';
+        }
     }
 --- request
 GET /t
@@ -1268,3 +1268,106 @@ failed to run healthcheck cycle
 --- error_log
 bad thing!
 --- timeout: 4
+
+
+
+=== TEST 14: health check with ipv6 backend (good case), status ignored by default
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+    server [::1]:12355;
+    server [0:0::1]:12356 backup;
+}
+
+server {
+    listen 12354;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen [::1]:12355;
+    location = /status {
+        return 404;
+    }
+}
+
+server {
+    listen [0:0::1]:12356;
+    location = /status {
+        return 503;
+    }
+}
+
+lua_shared_dict healthcheck 1m;
+init_worker_by_lua_block {
+    ngx.shared.healthcheck:flush_all()
+    local hc = require "resty.upstream.healthcheck"
+    local ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "foo.com",
+        type = "http",
+        http_req = "GET /status HTTP/1.0\r\nHost: localhost\r\n\r\n",
+        interval = 100,  -- 100ms
+        fall = 2,
+    }
+    if not ok then
+        ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
+        return
+    end
+}
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua_block {
+            ngx.sleep(0.52)
+
+            local hc = require "resty.upstream.healthcheck"
+            ngx.print(hc.status_page())
+
+            for i = 1, 2 do
+                local res = ngx.location.capture("/proxy")
+                ngx.say("upstream addr: ", res.header["X-Foo"])
+            end
+        }
+    }
+
+    location = /proxy {
+        proxy_pass http://foo.com/;
+        header_filter_by_lua_block {
+            ngx.header["X-Foo"] = ngx.var.upstream_addr;
+        }
+    }
+--- request
+GET /t
+
+--- response_body
+Upstream foo.com
+    Primary Peers
+        127.0.0.1:12354 up
+        [::1]:12355 up
+    Backup Peers
+        [0:0::1]:12356 up
+upstream addr: 127.0.0.1:12354
+upstream addr: [::1]:12355
+
+--- no_error_log
+[error]
+[alert]
+[warn]
+was checked to be not ok
+failed to run healthcheck cycle
+--- grep_error_log eval: qr/healthcheck: .*? was checked .*|publishing peers version \d+|upgrading peers version to \d+/
+--- grep_error_log_out eval
+qr/^healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
+healthcheck: peer \[::1\]:12355 was checked to be ok
+healthcheck: peer \[0:0::1\]:12356 was checked to be ok
+(?:healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
+healthcheck: peer \[::1\]:12355 was checked to be ok
+healthcheck: peer \[0:0::1\]:12356 was checked to be ok
+){3,7}$/
+--- timeout: 6


### PR DESCRIPTION
If the upstream peer name is something like [2001:123:123::123]:80 then the peers preprocess function splits the address at wrong index ([2001 and 123:123::123]:80 instead of [2001:123:123::123] and 80).
This little patch helps to split it at right place with a greedy pattern match.

name -> host, port
[2001:123:123::123]:80 -> [2001:123:123::123], 80
127.0.0.1:80 -> 127.0.0.1, 80
