### PR TITLE
Register callback functions when peers are marked down or up

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,13 +53,13 @@ http {
 
         -- this should be defined in a separate module to avoid a global function definition
         func_node_down = function(peer)
-            ngx.log(ngx.WARN, peer.name .. " is marked down")
+            ngx.log(ngx.WARN, peer.name, " is marked down")
 
-            -- do something else fancy with data about the peer, like notify a remote service
+            -- do something else fancy with the peer data, like notify a remote service
         end
 
         func_node_up = function(peer)
-            ngx.log(ngx.WARN, peer.name .. " is marked up")
+            ngx.log(ngx.WARN, peer.name, " is marked up")
         end
 
         local ok, err = hc.spawn_checker{

--- a/README.markdown
+++ b/README.markdown
@@ -51,6 +51,17 @@ http {
     init_worker_by_lua_block {
         local hc = require "resty.upstream.healthcheck"
 
+        -- this should be defined in a separate module to avoid a global function definition
+        func_node_down = function(peer)
+            ngx.log(ngx.WARN, peer.name .. " is marked down")
+
+            -- do something else fancy with data about the peer, like notify a remote service
+        end
+
+        func_node_up = function(peer)
+            ngx.log(ngx.WARN, peer.name .. " is marked up")
+        end
+
         local ok, err = hc.spawn_checker{
             shm = "healthcheck",  -- defined by "lua_shared_dict"
             upstream = "foo.com", -- defined by "upstream"
@@ -65,6 +76,8 @@ http {
             rise = 2,  -- # of successive successes before turning a peer up
             valid_statuses = {200, 302},  -- a list valid HTTP status code
             concurrency = 10,  -- concurrency level for test requests
+            hook_down = func_node_down, -- register a function to call when a node is marked down
+            hook_up = func_hook_up, -- register a function to call when a node is marked up
         }
         if not ok then
             ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
@@ -118,6 +131,10 @@ the specified NGINX upstream group with the specified shm storage.
 
 The healthchecker does not need any client traffic to function. The checks are performed actively
 and periodically.
+
+Note that two configuration options, `hook_down` and `hook_up`, can be defined and will fire when
+a node is marked as down, or up, respectively. The associated `peer` object is passed as a function
+param in both cases. Registering these functions is optional.
 
 This method call is asynchronous and returns immediately.
 

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -607,12 +607,12 @@ function _M.spawn_checker(opts)
 
     local hook_down = opts.hook_down
     if hook_down and type(hook_down) ~= "function" then
-        return nil, 'hook_down must be a function'
+        return nil, "hook_down must be a function"
     end
 
     local hook_up = opts.hook_up
     if hook_up and type(hook_up) ~= "function" then
-        return nil, 'hook_up must be a function'
+        return nil, "hook_up must be a function"
     end
 
     local ppeers, err = get_primary_peers(u)

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -146,7 +146,7 @@ local function peer_fail(ctx, is_backup, id, peer)
         peer.down = true
         set_peer_down_globally(ctx, is_backup, id, true)
 
-        if (ctx.hook_down) then
+        if ctx.hook_down then
             ctx.hook_down(peer)
         end
     end
@@ -203,7 +203,7 @@ local function peer_ok(ctx, is_backup, id, peer)
         peer.down = nil
         set_peer_down_globally(ctx, is_backup, id, nil)
 
-        if (ctx.hook_up) then
+        if ctx.hook_up then
             ctx.hook_up(peer)
         end
     end
@@ -606,12 +606,12 @@ function _M.spawn_checker(opts)
     end
 
     local hook_down = opts.hook_down
-    if (hook_down and type(hook_down) ~= 'function') then
+    if hook_down and type(hook_down) ~= "function" then
         return nil, 'hook_down must be a function'
     end
 
     local hook_up = opts.hook_up
-    if (hook_up and type(hook_up) ~= 'function') then
+    if hook_up and type(hook_up) ~= "function" then
         return nil, 'hook_up must be a function'
     end
 

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -145,6 +145,10 @@ local function peer_fail(ctx, is_backup, id, peer)
                 " failure(s)")
         peer.down = true
         set_peer_down_globally(ctx, is_backup, id, true)
+
+        if (ctx.hook_down) then
+            ctx.hook_down(peer)
+        end
     end
 end
 
@@ -198,6 +202,10 @@ local function peer_ok(ctx, is_backup, id, peer)
                 " success(es)")
         peer.down = nil
         set_peer_down_globally(ctx, is_backup, id, nil)
+
+        if (ctx.hook_up) then
+            ctx.hook_up(peer)
+        end
     end
 end
 
@@ -597,6 +605,16 @@ function _M.spawn_checker(opts)
         return nil, "no upstream specified"
     end
 
+    local hook_down = opts.hook_down
+    if (hook_down and type(hook_down) ~= 'function') then
+        return nil, 'hook_down must be a function'
+    end
+
+    local hook_up = opts.hook_up
+    if (hook_up and type(hook_up) ~= 'function') then
+        return nil, 'hook_up must be a function'
+    end
+
     local ppeers, err = get_primary_peers(u)
     if not ppeers then
         return nil, "failed to get primary peers: " .. err
@@ -620,6 +638,8 @@ function _M.spawn_checker(opts)
         statuses = statuses,
         version = 0,
         concurrency = concur,
+        hook_down = hook_down,
+        hook_up = hook_up,
     }
 
     local ok, err = new_timer(0, check, ctx)

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -9,7 +9,7 @@ use Cwd qw(cwd);
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6 + 9);
+plan tests => repeat_each() * (blocks() * 6 + 5);
 
 my $pwd = cwd();
 
@@ -1372,3 +1372,204 @@ healthcheck: peer \[0:0::1\]:12356 was checked to be ok
 ){3,7}$/
 --- timeout: 6
 --- skip_eval: 8: system("ping6 -c 1 ::1 >/dev/null 2>&1") ne 0
+
+
+
+
+
+=== TEST 15: hook_down fires as expected
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+    server 127.0.0.1:12355;
+    server 127.0.0.1:12356 backup;
+}
+
+server {
+    listen 12354;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen 12355;
+    location = /status {
+        return 503;
+    }
+}
+
+server {
+    listen 12356;
+    location = /status {
+        return 503;
+    }
+}
+
+lua_shared_dict healthcheck 1m;
+init_worker_by_lua '
+    ngx.shared.healthcheck:flush_all()
+    local hc = require "resty.upstream.healthcheck"
+
+    node_down = function(peer)
+        ngx.log(ngx.WARN, peer.name .. " marked as down")
+    end
+
+    local ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "foo.com",
+        type = "http",
+        http_req = "GET /status HTTP/1.0\\\\r\\\\nHost: localhost\\\\r\\\\n\\\\r\\\\n",
+        interval = 100,  -- 100ms
+        valid_statuses = { 200 },
+        fall = 2,
+        hook_down = node_down,
+    }
+    if not ok then
+        ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
+        return
+    end
+';
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua '
+            ngx.sleep(0.52)
+
+            local hc = require "resty.upstream.healthcheck"
+            ngx.print(hc.status_page())
+
+            for i = 1, 2 do
+                local res = ngx.location.capture("/proxy")
+                ngx.say("upstream addr: ", res.header["X-Foo"])
+            end
+        ';
+    }
+
+    location = /proxy {
+        proxy_pass http://foo.com/;
+        header_filter_by_lua '
+            ngx.header["X-Foo"] = ngx.var.upstream_addr;
+        ';
+    }
+--- request
+GET /t
+--- response_body
+
+Upstream foo.com
+    Primary Peers
+        127.0.0.1:12354 up
+        127.0.0.1:12355 DOWN
+    Backup Peers
+        127.0.0.1:12356 DOWN
+upstream addr: 127.0.0.1:12354
+upstream addr: 127.0.0.1:12354
+--- error_log
+127.0.0.1:12355 marked as down
+--- no_error_log
+[alert]
+--- timeout: 6
+
+
+=== TEST 16: hook_up fires as expected
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+    server 127.0.0.1:12355;
+    server 127.0.0.1:12356 backup;
+}
+
+server {
+    listen 12354;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen 12355;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen 12356;
+    location = /status {
+        return 503;
+    }
+}
+
+lua_shared_dict healthcheck 1m;
+init_worker_by_lua '
+    ngx.shared.healthcheck:flush_all()
+    local hc = require "resty.upstream.healthcheck"
+
+    node_up = function(peer)
+        ngx.log(ngx.WARN, peer.name .. " marked as up")
+    end
+
+    -- mock a previous failure
+    local upstream = require "ngx.upstream"
+    upstream.set_peer_down("foo.com", false, 1, true)
+
+    local ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "foo.com",
+        type = "http",
+        http_req = "GET /status HTTP/1.0\\\\r\\\\nHost: localhost\\\\r\\\\n\\\\r\\\\n",
+        interval = 100,  -- 100ms
+        valid_statuses = { 200 },
+        fall = 2,
+        hook_up = node_up,
+    }
+    if not ok then
+        ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
+        return
+    end
+';
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua '
+            ngx.sleep(0.52)
+
+            local hc = require "resty.upstream.healthcheck"
+            ngx.print(hc.status_page())
+
+            for i = 1, 2 do
+                local res = ngx.location.capture("/proxy")
+                ngx.say("upstream addr: ", res.header["X-Foo"])
+            end
+        ';
+    }
+
+    location = /proxy {
+        proxy_pass http://foo.com/;
+        header_filter_by_lua '
+            ngx.header["X-Foo"] = ngx.var.upstream_addr;
+        ';
+    }
+--- request
+GET /t
+--- response_body
+
+Upstream foo.com
+    Primary Peers
+        127.0.0.1:12354 up
+        127.0.0.1:12355 up
+    Backup Peers
+        127.0.0.1:12356 DOWN
+upstream addr: 127.0.0.1:12354
+upstream addr: 127.0.0.1:12355
+--- error_log
+127.0.0.1:12355 marked as up
+--- no_error_log
+[alert]
+--- timeout: 6


### PR DESCRIPTION
Call an optional user-defined function when peer_fail or peer_ok
change the status of a peer object via set_peer_down_globally.
This allows arbitrarily extending the response to upstream health
changes.