### PR TITLE
Support HealtchCheck on tcp layer，avoid to produce needless http access log

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,11 @@ http {
         server 127.0.0.1:12355;
         server 127.0.0.1:12356 backup;
     }
+    upstream goo.com {
+        server 127.0.0.1:12314;
+        server 127.0.0.1:12315;
+        server 127.0.0.1:12316 backup;
+    }
 
     # the size depends on the number of servers in upstream {}:
     lua_shared_dict healthcheck 1m;
@@ -55,7 +60,7 @@ http {
             shm = "healthcheck",  -- defined by "lua_shared_dict"
             upstream = "foo.com", -- defined by "upstream"
             type = "http",
-
+            
             http_req = "GET /status HTTP/1.0\r\nHost: foo.com\r\n\r\n",
                     -- raw HTTP request for checking
 
@@ -75,6 +80,19 @@ http {
         -- more upstream groups to monitor. One call for one upstream group.
         -- They can all share the same shm zone without conflicts but they
         -- need a bigger shm zone for obvious reasons.
+        
+        -- example of helthcheck for tcp
+        local ok, err = hc.spawn_checker{
+            shm = "healthcheck",  -- defined by "lua_shared_dict"
+            upstream = "foo.com", -- defined by "upstream"
+            type = "tcp",
+            interval = 2000,  -- run the check cycle every 2 sec
+            timeout = 1000,   -- 1 sec is the timeout for network operations
+            fall = 3,  -- # of successive failures before turning a peer down
+            rise = 2,  -- # of successive successes before turning a peer up
+            concurrency = 10,  -- concurrency level for test requests
+        }
+
     }
 
     server {

--- a/README.markdown
+++ b/README.markdown
@@ -42,11 +42,6 @@ http {
         server 127.0.0.1:12355;
         server 127.0.0.1:12356 backup;
     }
-    upstream goo.com {
-        server 127.0.0.1:12314;
-        server 127.0.0.1:12315;
-        server 127.0.0.1:12316 backup;
-    }
 
     # the size depends on the number of servers in upstream {}:
     lua_shared_dict healthcheck 1m;
@@ -59,31 +54,27 @@ http {
         local ok, err = hc.spawn_checker{
             shm = "healthcheck",  -- defined by "lua_shared_dict"
             upstream = "foo.com", -- defined by "upstream"
-            type = "http",            
+            type = "http",
+
             http_req = "GET /status HTTP/1.0\r\nHost: foo.com\r\n\r\n",
                     -- raw HTTP request for checking
+
             interval = 2000,  -- run the check cycle every 2 sec
             timeout = 1000,   -- 1 sec is the timeout for network operations
             fall = 3,  -- # of successive failures before turning a peer down
             rise = 2,  -- # of successive successes before turning a peer up
             valid_statuses = {200, 302},  -- a list valid HTTP status code
             concurrency = 10,  -- concurrency level for test requests
-        }        
+        }
         if not ok then
             ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
             return
         end
-
-        -- Just call hc.spawn_checker() for more times here if you have
-        -- more upstream groups to monitor. One call for one upstream group.
-        -- They can all share the same shm zone without conflicts but they
-        -- need a bigger shm zone for obvious reasons.
         
-        -- example of helthcheck for tcp
-        
-        local ok, err = hc.spawn_checker{
+        -- Example of HealthCheck for Tcp
+        local ok, err = hc.spawn_checker{
             shm = "healthcheck",  -- defined by "lua_shared_dict"
-            upstream = "goo.com", -- defined by "upstream"
+            upstream = "foo.com", -- defined by "upstream"
             type = "tcp",
             interval = 2000,  -- run the check cycle every 2 sec
             timeout = 1000,   -- 1 sec is the timeout for network operations
@@ -92,6 +83,10 @@ http {
             concurrency = 10,  -- concurrency level for test requests
         }
 
+        -- Just call hc.spawn_checker() for more times here if you have
+        -- more upstream groups to monitor. One call for one upstream group.
+        -- They can all share the same shm zone without conflicts but they
+        -- need a bigger shm zone for obvious reasons.
     }
 
     server {

--- a/README.markdown
+++ b/README.markdown
@@ -68,7 +68,7 @@ http {
             rise = 2,  -- # of successive successes before turning a peer up
             valid_statuses = {200, 302},  -- a list valid HTTP status code
             concurrency = 10,  -- concurrency level for test requests
-        }
+        }        
         if not ok then
             ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
             return
@@ -83,7 +83,7 @@ http {
         
         local ok, err = hc.spawn_checker{
             shm = "healthcheck",  -- defined by "lua_shared_dict"
-            upstream = "foo.com", -- defined by "upstream"
+            upstream = "goo.com", -- defined by "upstream"
             type = "tcp",
             interval = 2000,  -- run the check cycle every 2 sec
             timeout = 1000,   -- 1 sec is the timeout for network operations

--- a/README.markdown
+++ b/README.markdown
@@ -82,6 +82,7 @@ http {
         -- need a bigger shm zone for obvious reasons.
         
         -- example of helthcheck for tcp
+        
         local ok, err = hc.spawn_checker{
             shm = "healthcheck",  -- defined by "lua_shared_dict"
             upstream = "foo.com", -- defined by "upstream"

--- a/README.markdown
+++ b/README.markdown
@@ -59,11 +59,9 @@ http {
         local ok, err = hc.spawn_checker{
             shm = "healthcheck",  -- defined by "lua_shared_dict"
             upstream = "foo.com", -- defined by "upstream"
-            type = "http",
-            
+            type = "http",            
             http_req = "GET /status HTTP/1.0\r\nHost: foo.com\r\n\r\n",
                     -- raw HTTP request for checking
-
             interval = 2000,  -- run the check cycle every 2 sec
             timeout = 1000,   -- 1 sec is the timeout for network operations
             fall = 3,  -- # of successive failures before turning a peer down

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -531,7 +531,7 @@ function _M.spawn_checker(opts)
     end
 
     if typ ~= "http" and typ ~= "tcp" then
-        return nil, "only \"http\" type is supported right now"
+        return nil, "only \"http\" or \"tcp\" type is supported right now"
     end
 
     local http_req = opts.http_req

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -228,6 +228,12 @@ local function check_peer(ctx, id, peer, is_backup)
             errlog("failed to connect to ", name, ": ", err)
         end
         return peer_fail(ctx, is_backup, id, peer)
+    else 
+        if ctx.type == "tcp" then
+           peer_ok(ctx, is_backup, id, peer)
+           sock:close()
+           return
+        end    
     end
 
     local bytes, err = sock:send(req)
@@ -524,12 +530,12 @@ function _M.spawn_checker(opts)
         return nil, "\"type\" option required"
     end
 
-    if typ ~= "http" then
+    if typ ~= "http" and typ ~= "tcp" then
         return nil, "only \"http\" type is supported right now"
     end
 
     local http_req = opts.http_req
-    if not http_req then
+    if typ == "http" and not http_req then
         return nil, "\"http_req\" option required"
     end
 
@@ -602,6 +608,7 @@ function _M.spawn_checker(opts)
     end
 
     local ctx = {
+        type = typ,
         upstream = u,
         primary_peers = preprocess_peers(ppeers),
         backup_peers = preprocess_peers(bpeers),


### PR DESCRIPTION
local ok, err = hc.spawn_checker{
            shm = "healthcheck",  -- defined by "lua_shared_dict"
            upstream = "foo.com", -- defined by "upstream"
            type = "tcp",
            interval = 2000,  -- run the check cycle every 2 sec
            timeout = 1000,   -- 1 sec is the timeout for network operations
            fall = 3,  -- # of successive failures before turning a peer down
            rise = 2,  -- # of successive successes before turning a peer up
            concurrency = 10,  -- concurrency level for test requests
        }
