### PR TITLE
fix description error in readme.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -188,22 +188,20 @@ lua_shared_dict healthcheck 1m;
 lua_socket_log_errors off;
 
 init_worker_by_lua_block {
-    init_worker_by_lua_block {
-        local hc = require "resty.upstream.healthcheck"
+    local hc = require "resty.upstream.healthcheck"
 
-        local ok, err = hc.spawn_checker{
-            shm = "healthcheck",
-            upstream = "foo",
-            ...
-        }
-
+    local ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "foo",
         ...
+    }
 
-        ok, err = hc.spawn_checker{
-            shm = "healthcheck",
-            upstream = "bar",
-            ...
-        }
+    ...
+
+    ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "bar",
+        ...
     }
 }
 ```


### PR DESCRIPTION
Fix the description of Multiple Upstreams,nested 'init_worker_by_lua_block' do not work properly.
for my validation: 
nginx.conf:
```
lua_shared_dict healthcheck 1m; 
   init_worker_by_lua_block {
       init_worker_by_lua_block {
           local hc = require "resty.upstream.healthcheck"
           local ok, err = hc.spawn_checker{
           shm = "healthcheck",  -- defined by "lua_shared_dict"
           upstream = "test.web.com", -- defined by "upstream"
           type = "http",
            ......
```
error message:
```
[error] 31204#31204: init_worker_by_lua error: init_worker_by_lua:3: unexpected symbol near 'local'
```