### PR TITLE
Bad local

### DIFF
--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -313,7 +313,7 @@ local function check_peers(ctx, peers, is_backup)
 
         else
             local group_size = ceil(n / concur)
-            local nthr = ceil(n / group_size) - 1
+            nthr = ceil(n / group_size) - 1
 
             threads = new_tab(nthr, 0)
             local from = 1


### PR DESCRIPTION
`nthr` is created on line 293. Then a new one on line 316 shadows the outer one. This means that values set on the inner one will be lost when the scope ends, and on line 356, the result will always be falsy, and hence the code will never run.

Fixes #16