### PR TITLE
Mistake shadowing variable

### DIFF
--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -313,7 +313,7 @@ local function check_peers(ctx, peers, is_backup)
 
         else
             local group_size = ceil(n / concur)
-            local nthr = ceil(n / group_size) - 1
+            nthr = ceil(n / group_size) - 1
 
             threads = new_tab(nthr, 0)
             local from = 1


### PR DESCRIPTION
Hello !
Doing the conversion of openresty to use https://github.com/mingodad/ljsjit I found what seems to be a mistake of redeclaring a variable.
Looking at the code it seems that the intention is to use an already declared variable and refer to it afterwards.
Cheers !