### PR TITLE
Added the "expected_result" parameter to the options as a response body checker.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,6 +64,7 @@ http {
             fall = 3,  -- # of successive failures before turning a peer down
             rise = 2,  -- # of successive successes before turning a peer up
             valid_statuses = {200, 302},  -- a list valid HTTP status code
+            expected_string = "I'm alive =)", -- Expected as a result of the request
             concurrency = 10,  -- concurrency level for test requests
         }
         if not ok then

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -552,7 +552,7 @@ function _M.spawn_checker(opts)
 
     local expected_string = opts.expected_string
     if not expected_string then
-        expected_string = ".*"
+        expected_string = nil
     end
 
     local http_req = opts.http_req

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -236,7 +236,7 @@ local function check_peer(ctx, id, peer, is_backup)
                           "failed to send request to ", name, ": ", err)
     end
 
-    local status_line, err = sock:receive()
+    local status_line, err = sock:receive("*a")
     if not status_line then
         peer_error(ctx, is_backup, id, peer,
                    "failed to receive status line from ", name, ": ", err)
@@ -532,6 +532,11 @@ function _M.spawn_checker(opts)
         return nil, "only \"http\" type is supported right now"
     end
 
+    local expected_string = opts.expected_string
+    if not expected_string then
+        expected_string = ".*"
+    end
+
     local http_req = opts.http_req
     if not http_req then
         return nil, "\"http_req\" option required"
@@ -618,6 +623,7 @@ function _M.spawn_checker(opts)
         statuses = statuses,
         version = 0,
         concurrency = concur,
+        expected_string = expected_string
     }
 
     if debug_mode and opts.no_timer then

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -262,8 +262,7 @@ local function check_peer(ctx, id, peer, is_backup)
 
         local status = tonumber(sub(status_line, from, to))
         if not statuses[status] then
-            peer_error(ctx, is_backup, id, peer, "bad status code from ",
-                       name, ": ", status)
+            peer_error(ctx, is_backup, id, peer, "bad status code from ", name, ": ", status)
             sock:close()
             return
         end
@@ -271,7 +270,7 @@ local function check_peer(ctx, id, peer, is_backup)
 
     -- Expected string check area
     if expected_string then
-        local from, to, err = re_find(status_line, [[(]] .. expected_string .. [[])]], "joi", nil, 1)
+        local from, to, err = re_find(status_line, "(".. expected_string ..")", "joi", nil, 1)
         if err then
             errlog("failed to parse expected string line: ", err)
         end
@@ -283,7 +282,11 @@ local function check_peer(ctx, id, peer, is_backup)
         end
 
         local status = sub(status_line, from, to)
-        errlog("Expected string: ", status)
+        if not status then
+            peer_error(ctx, is_backup, id, peer, "bad expected string from ", name, ": ", status)
+            sock:close()
+            return
+        end
     end
 
     peer_ok(ctx, is_backup, id, peer)


### PR DESCRIPTION
Hi All;

I'm developed some lines of code for search some string in response body and decide this upstream member is up or down. I hope to this feature will be useful for everyone. I'm also made some performance tests to see if there is any performance gap. I'm sharing results with you. You will see some error in screen shots. There is no problem. Because, these errors happened during the changing my backend server configuration. (300 concurrent user)
![lua_results_1](https://user-images.githubusercontent.com/12031564/55582549-797c2c00-5728-11e9-9fa9-c79f31461e57.png)
![lua_results_2](https://user-images.githubusercontent.com/12031564/55582594-957fcd80-5728-11e9-9510-db3156b7e981.png)
![lua_results_3](https://user-images.githubusercontent.com/12031564/55582627-ad575180-5728-11e9-9cc8-a98e5980d5b8.png)


