### PR TITLE
Fix opts.host not been assigned to ctx

### DIFF
--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -633,7 +633,7 @@ function _M.spawn_checker(opts)
         version = 0,
         concurrency = concur,
         type = typ,
-        host = host,
+        host = opts.host,
         ssl_verify = ssl_verify
     }
 


### PR DESCRIPTION
Seems new param `host` has not been assigned to ctx properly. which leads to wrong upstream status when ssl_verify = true