### PR TITLE
feature: report the probed port in error logs and on the status page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -183,6 +183,20 @@ Upstream foo.com (NO checkers)
         127.0.0.1:12356 UP
 ```
 
+If a checker was spawned with the `port` option (so peers are probed on a port
+other than the one they are configured with in the `upstream` block), the
+probed port is shown next to each peer, since that is the port the UP/DOWN
+state was actually measured against:
+
+```
+Upstream foo.com
+    Primary Peers
+        127.0.0.1:12354 (probe :8081) UP
+        127.0.0.1:12355 (probe :8081) DOWN
+    Backup Peers
+        127.0.0.1:12356 (probe :8081) UP
+```
+
 If you indeed have spawned a healthchecker in `init_worker_by_lua*`, then you should really
 check out the NGINX error log file to see if there is any fatal errors aborting the healthchecker threads.
 

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -52,6 +52,7 @@ local get_backup_peers = upstream.get_backup_peers
 local get_upstreams = upstream.get_upstreams
 
 local upstream_checker_statuses = {}
+local upstream_checker_ports = {}
 
 local function warn(...)
     log(WARN, "healthcheck: ", ...)
@@ -212,6 +213,9 @@ end
 local function check_peer(ctx, id, peer, is_backup)
     local ok
     local name = peer.name
+    if peer.host and peer.port then
+        name = peer.host .. ":" .. peer.port
+    end
     local statuses = ctx.statuses
     local req = ctx.http_req
 
@@ -668,6 +672,7 @@ function _M.spawn_checker(opts)
     end
 
     update_upstream_checker_status(u, true)
+    upstream_checker_ports[u] = opts.port
 
     return true
 end
@@ -747,11 +752,17 @@ local function add_peer_prometheus_status(tab, u, p, r)
 end
 
 local function add_peers_info(tab, u, peers, role)
+    local probe_port = upstream_checker_ports[u]
     local npeers = #peers
     for i = 1, npeers do
         local peer = peers[i]
         tab:add("        ")
         tab:add(peer.name)
+        if probe_port then
+            tab:add(" (probe :")
+            tab:add(probe_port)
+            tab:add(")")
+        end
         if peer.down then
             tab:add(" DOWN\n")
         else

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -9,7 +9,7 @@ use Cwd qw(cwd);
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6 + 11);
+plan tests => repeat_each() * (blocks() * 6 + 8);
 
 my $pwd = cwd();
 
@@ -1536,8 +1536,8 @@ GET /t
 --- response_body
 Upstream foo.com
     Primary Peers
-        127.0.0.1:12354 UP
-        127.0.0.1:12355 UP
+        127.0.0.1:12354 (probe :12356) UP
+        127.0.0.1:12355 (probe :12356) UP
     Backup Peers
 upstream addr: 127.0.0.1:12354
 upstream addr: 127.0.0.1:12355
@@ -1554,4 +1554,56 @@ healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 (?:healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 ){3,5}$/
+--- timeout: 6
+
+
+
+=== TEST 17: health check using different port, failed probe names the probe port
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+}
+server {
+    listen 12354;
+    location = /status {
+        return 200;
+    }
+}
+lua_shared_dict healthcheck 1m;
+init_worker_by_lua '
+    ngx.config.debug = 1
+    ngx.shared.healthcheck:flush_all()
+    local hc = require "resty.upstream.healthcheck"
+    local ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "foo.com",
+        type = "http",
+        http_req = "GET /status HTTP/1.0\\\\r\\\\nHost: localhost\\\\r\\\\n\\\\r\\\\n",
+        interval = 100,  -- 100ms
+        fall = 1,
+        port = 12356,
+    }
+    if not ok then
+        ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
+        return
+    end
+';
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua '
+            ngx.sleep(0.32)
+            ngx.say("ok")
+        ';
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- grep_error_log eval: qr/failed to connect to [\d.]+:\d+/
+--- grep_error_log_out eval
+qr/^(?:failed to connect to 127\.0\.0\.1:12356\n)+$/
 --- timeout: 6


### PR DESCRIPTION
The `port` option lets `spawn_checker` probe a port other than the one a peer is configured with in the `upstream` block. But that target was never reflected back to the operator: the check error messages and `status_page()` both printed `peer.name` (the *configured* `host:port`), so a failing probe appeared to hit the peer's own port rather than the port actually probed.

This makes the probe port visible in both places:

- **Error logs:** the name used in `check_peer`'s messages is derived from `peer.host:peer.port` (the address `sock:connect` actually used). When no `port` override is set this equals `peer.name`, so existing output is unchanged.
- **Status page:** each peer is annotated with `(probe :PORT)` when a `port` override is in effect for that upstream; output is unchanged otherwise.

Example `status_page()` output with `port = 8081`:

```
Upstream foo.com
    Primary Peers
        127.0.0.1:12354 (probe :8081) UP
        127.0.0.1:12355 (probe :8081) DOWN
    Backup Peers
        127.0.0.1:12356 (probe :8081) UP
```

Tests: extended the existing different-port test in `t/sanity.t` (TEST 16) to assert the status-page annotation, and added a failing-probe case (TEST 17) asserting the probe port appears in the error log. Documented the annotation in the README. No behavioural change to health checking itself - only how the probe target is reported.
