### PR TITLE
feature: support "tcp" health check type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,10 +56,12 @@ http {
         local ok, err = hc.spawn_checker{
             shm = "healthcheck",  -- defined by "lua_shared_dict"
             upstream = "foo.com", -- defined by "upstream"
-            type = "http", -- support "http" and "https"
+            type = "http", -- support "http", "https" and "tcp"
 
             http_req = "GET /status HTTP/1.0\r\nHost: foo.com\r\n\r\n",
-                    -- raw HTTP request for checking
+                    -- raw HTTP request for checking, required for "http" and
+                    -- "https" types, ignored for "tcp" (which only opens a
+                    -- connection to verify the peer is reachable)
 
             port = nil,  -- the check port, it can be different than the original backend server port, default means the same as the original backend server
             interval = 2000,  -- run the check cycle every 2 sec
@@ -140,6 +142,17 @@ The healthchecker does not need any client traffic to function. The checks are p
 and periodically.
 
 This method call is asynchronous and returns immediately.
+
+The `type` option selects how a peer is probed:
+
+* `"http"`: send `http_req` and check the response status line (the default behavior).
+* `"https"`: same as `"http"`, but a TLS handshake is performed first.
+* `"tcp"`: only open a TCP connection to the peer; the peer is considered healthy
+  if the connection succeeds. `http_req` is not required for this type. This is
+  useful for checking non-HTTP backends without producing needless access log entries.
+  Set `ssl = true` to also perform a TLS handshake after connecting (the peer is
+  healthy only if the handshake succeeds); `ssl_verify` and `host` apply as they do
+  for the `"https"` type.
 
 Returns true on success, or `nil` and a string describing an error otherwise.
 

--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -236,13 +236,19 @@ local function check_peer(ctx, id, peer, is_backup)
         return peer_fail(ctx, is_backup, id, peer)
     end
 
-    if ctx.type == "https" then
+    if ctx.type == "https" or (ctx.type == "tcp" and ctx.ssl) then
         ok, err = sock:sslhandshake(nil, ctx.host, ctx.ssl_verify)
         if not ok then
             sock:close()
             return peer_error(ctx, is_backup, id, peer,
                               "failed to ssl handshake to ", name, ": ", err)
         end
+    end
+
+    if ctx.type == "tcp" then
+        peer_ok(ctx, is_backup, id, peer)
+        sock:close()
+        return
     end
 
     local bytes, err = sock:send(req)
@@ -556,8 +562,8 @@ function _M.spawn_checker(opts)
         return nil, "\"type\" option required"
     end
 
-    if typ ~= "http" and typ ~= "https" then
-        return nil, "only \"http\" and \"https\" type are supported right now"
+    if typ ~= "http" and typ ~= "https" and typ ~= "tcp" then
+        return nil, "only \"http\", \"https\" and \"tcp\" type are supported right now"
     end
 
     local ssl_verify = opts.ssl_verify
@@ -566,7 +572,7 @@ function _M.spawn_checker(opts)
     end
 
     local http_req = opts.http_req
-    if not http_req then
+    if typ ~= "tcp" and not http_req then
         return nil, "\"http_req\" option required"
     end
 
@@ -654,6 +660,7 @@ function _M.spawn_checker(opts)
         concurrency = concur,
         type = typ,
         host = opts.host,
+        ssl = opts.ssl,
         ssl_verify = ssl_verify
     }
 

--- a/t/tcp.t
+++ b/t/tcp.t
@@ -1,0 +1,278 @@
+# vim:set ft= ts=4 sw=4 t fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 2);
+
+my $pwd = cwd();
+
+our $HttpConfig = <<_EOC_;
+    lua_socket_log_errors off;
+    lua_package_path "$pwd/../lua-resty-lock/?.lua;$pwd/lib/?.lua;$pwd/t/lib/?.lua;;";
+_EOC_
+
+#no_diff();
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: tcp health check (good case), only the connection is probed
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+    server 127.0.0.1:12355;
+    server 127.0.0.1:12356 backup;
+}
+
+server {
+    listen 12354;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen 12355;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen 12356;
+    location = /status {
+        return 200;
+    }
+}
+
+lua_shared_dict healthcheck 1m;
+
+init_worker_by_lua '
+    ngx.shared.healthcheck:flush_all()
+    local hc = require "resty.upstream.healthcheck"
+    local ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "foo.com",
+        type = "tcp",
+        interval = 100,  -- 100ms
+        fall = 2,
+    }
+    if not ok then
+        ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
+        return
+    end
+';
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua '
+            ngx.sleep(0.52)
+
+            local hc = require "resty.upstream.healthcheck"
+            ngx.print(hc.status_page())
+
+            for i = 1, 2 do
+                local res = ngx.location.capture("/proxy")
+                ngx.say("upstream addr: ", res.header["X-Foo"])
+            end
+        ';
+    }
+
+    location = /proxy {
+        proxy_pass http://foo.com/;
+        header_filter_by_lua '
+            ngx.header["X-Foo"] = ngx.var.upstream_addr;
+        ';
+    }
+
+--- request
+GET /t
+
+--- response_body
+Upstream foo.com
+    Primary Peers
+        127.0.0.1:12354 UP
+        127.0.0.1:12355 UP
+    Backup Peers
+        127.0.0.1:12356 UP
+upstream addr: 127.0.0.1:12354
+upstream addr: 127.0.0.1:12355
+--- timeout: 6
+
+
+
+=== TEST 2: tcp health check (bad case), a peer with no listening port is turned down
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+    server 127.0.0.1:12355;
+    server 127.0.0.1:12356 backup;
+}
+
+server {
+    listen 12354;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen 12356;
+    location = /status {
+        return 200;
+    }
+}
+
+lua_shared_dict healthcheck 1m;
+
+init_worker_by_lua '
+    ngx.shared.healthcheck:flush_all()
+    local hc = require "resty.upstream.healthcheck"
+    local ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "foo.com",
+        type = "tcp",
+        interval = 100,  -- 100ms
+        fall = 2,
+    }
+    if not ok then
+        ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
+        return
+    end
+';
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua '
+            ngx.sleep(0.52)
+
+            local hc = require "resty.upstream.healthcheck"
+            ngx.print(hc.status_page())
+
+            for i = 1, 2 do
+                local res = ngx.location.capture("/proxy")
+                ngx.say("upstream addr: ", res.header["X-Foo"])
+            end
+        ';
+    }
+
+    location = /proxy {
+        proxy_pass http://foo.com/;
+        header_filter_by_lua '
+            ngx.header["X-Foo"] = ngx.var.upstream_addr;
+        ';
+    }
+
+--- request
+GET /t
+
+--- response_body
+Upstream foo.com
+    Primary Peers
+        127.0.0.1:12354 UP
+        127.0.0.1:12355 DOWN
+    Backup Peers
+        127.0.0.1:12356 UP
+upstream addr: 127.0.0.1:12354
+upstream addr: 127.0.0.1:12354
+--- timeout: 6
+
+
+
+=== TEST 3: tcp health check with ssl handshake (good case)
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+    server 127.0.0.1:12355;
+    server 127.0.0.1:12356 backup;
+}
+
+server {
+    listen 12354 ssl;
+    server_name localhost;
+    ssl_certificate     ../../cert/localhost.crt;
+    ssl_certificate_key ../../cert/localhost.key;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen 12355 ssl;
+    server_name localhost;
+    ssl_certificate     ../../cert/localhost.crt;
+    ssl_certificate_key ../../cert/localhost.key;
+    location = /status {
+        return 200;
+    }
+}
+
+server {
+    listen 12356 ssl;
+    server_name localhost;
+    ssl_certificate     ../../cert/localhost.crt;
+    ssl_certificate_key ../../cert/localhost.key;
+    location = /status {
+        return 200;
+    }
+}
+
+lua_shared_dict healthcheck 1m;
+
+init_worker_by_lua '
+    ngx.shared.healthcheck:flush_all()
+    local hc = require "resty.upstream.healthcheck"
+    local ok, err = hc.spawn_checker{
+        shm = "healthcheck",
+        upstream = "foo.com",
+        type = "tcp",
+        ssl = true,
+        ssl_verify = false,
+        host = "localhost",
+        interval = 100,  -- 100ms
+        fall = 2,
+    }
+    if not ok then
+        ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
+        return
+    end
+';
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua '
+            ngx.sleep(0.52)
+
+            local hc = require "resty.upstream.healthcheck"
+            ngx.print(hc.status_page())
+        ';
+    }
+
+--- request
+GET /t
+
+--- response_body
+Upstream foo.com
+    Primary Peers
+        127.0.0.1:12354 UP
+        127.0.0.1:12355 UP
+    Backup Peers
+        127.0.0.1:12356 UP
+--- timeout: 6


### PR DESCRIPTION
Adds a new `tcp` health check type. It only opens a TCP connection to the peer. If the connection works, the peer is marked up. No HTTP request is sent, so it does not create access log entries on the upstream and can check non-HTTP backends.

For `tcp`, the `http_req` option is not needed.

You can also set `ssl = true` to do a TLS handshake after connecting (still no HTTP request). This lets you check TLS-only backends. `ssl_verify` and `host` work the same way as for the `https` type.

This implements the feature from #46, which has been open for a long time. That PR was made before `https` support was added and no longer applies. It also addresses the review comments left there: the type error message is kept in sync, the new branch is not nested in an `else`, and tests are included.

Resolves #25.

Tests: added `t/tcp.t` with a good case, a peer with no listener, and a case using the TLS handshake. All tests pass.
