### PR TITLE
feature: include the upstream name in peer log messages

### DIFF
--- a/lib/resty/upstream/healthcheck.lua
+++ b/lib/resty/upstream/healthcheck.lua
@@ -143,7 +143,8 @@ local function peer_fail(ctx, is_backup, id, peer)
     -- ", fails: ", fails)
 
     if not peer.down and fails >= ctx.fall then
-        warn("peer ", peer.name, " is turned down after ", fails, " failure(s)")
+        warn("peer ", peer.name, " is turned down after ", fails,
+             " failure(s) in upstream ", ctx.upstream)
         peer.down = true
         set_peer_down_globally(ctx, is_backup, id, true)
     end
@@ -195,7 +196,8 @@ local function peer_ok(ctx, is_backup, id, peer)
     end
 
     if peer.down and succ >= ctx.rise then
-        warn("peer ", peer.name, " is turned up after ", succ, " success(es)")
+        warn("peer ", peer.name, " is turned up after ", succ,
+             " success(es) in upstream ", ctx.upstream)
         peer.down = nil
         set_peer_down_globally(ctx, is_backup, id, nil)
     end
@@ -230,10 +232,9 @@ local function check_peer(ctx, id, peer, is_backup)
         ok, err = sock:connect(name)
     end
     if not ok then
-        if not peer.down then
-            errlog("failed to connect to ", name, ": ", err)
-        end
-        return peer_fail(ctx, is_backup, id, peer)
+        return peer_error(ctx, is_backup, id, peer,
+                          "failed to connect to ", name, ": ", err,
+                          " in upstream ", ctx.upstream)
     end
 
     if ctx.type == "https" then
@@ -241,14 +242,16 @@ local function check_peer(ctx, id, peer, is_backup)
         if not ok then
             sock:close()
             return peer_error(ctx, is_backup, id, peer,
-                              "failed to ssl handshake to ", name, ": ", err)
+                              "failed to ssl handshake to ", name, ": ", err,
+                              " in upstream ", ctx.upstream)
         end
     end
 
     local bytes, err = sock:send(req)
     if not bytes then
         peer_error(ctx, is_backup, id, peer,
-                   "failed to send request to ", name, ": ", err)
+                   "failed to send request to ", name, ": ", err,
+                   " in upstream ", ctx.upstream)
         if err == "timeout" then
             sock:close() -- timeout errors do not close the socket.
         end
@@ -258,7 +261,8 @@ local function check_peer(ctx, id, peer, is_backup)
     local status_line, err = sock:receive()
     if not status_line then
         peer_error(ctx, is_backup, id, peer,
-                   "failed to receive status line from ", name, ": ", err)
+                   "failed to receive status line from ", name, ": ", err,
+                   " in upstream ", ctx.upstream)
         if err == "timeout" then
             sock:close() -- timeout errors do not close the socket.
         end
@@ -274,7 +278,7 @@ local function check_peer(ctx, id, peer, is_backup)
 
         if not from then
             peer_error(ctx, is_backup, id, peer, "bad status line from ", name,
-                       ": ", status_line)
+                       ": ", status_line, " in upstream ", ctx.upstream)
             sock:close()
             return
         end
@@ -282,7 +286,7 @@ local function check_peer(ctx, id, peer, is_backup)
         local status = tonumber(sub(status_line, from, to))
         if not statuses[status] then
             peer_error(ctx, is_backup, id, peer, "bad status code from ", name,
-                       ": ", status)
+                       ": ", status, " in upstream ", ctx.upstream)
             sock:close()
             return
         end

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -210,7 +210,7 @@ upstream addr: 127.0.0.1:12355
 [alert]
 failed to run healthcheck cycle
 --- error_log
-healthcheck: failed to connect to 127.0.0.1:12356: connection refused
+healthcheck: failed to connect to 127.0.0.1:12356: connection refused in upstream foo.com
 --- grep_error_log eval: qr/healthcheck: .*? was checked .*|warn\(\): .*(?=,)|publishing peers version \d+|upgrading peers version to \d+/
 --- grep_error_log_out eval
 qr/^healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
@@ -219,7 +219,7 @@ healthcheck: peer 127\.0\.0\.1:12356 was checked to be not ok
 healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be not ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12356 is turned down after 2 failure\(s\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12356 is turned down after 2 failure\(s\) in upstream foo\.com
 publishing peers version 1
 (?:healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
@@ -319,7 +319,7 @@ healthcheck: peer 127\.0\.0\.1:12355 was checked to be not ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be not ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned down after 2 failure\(s\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned down after 2 failure\(s\) in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 (?:healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be not ok
@@ -420,13 +420,13 @@ failed to run healthcheck cycle
 --- grep_error_log eval: qr/healthcheck: .*? was checked .*|warn\(\): .*(?=,)|healthcheck: bad status code from .*(?=,)|upgrading peers version to \d+/
 --- grep_error_log_out eval
 qr/^healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
-healthcheck: bad status code from 127\.0\.0\.1:12355: 404
+healthcheck: bad status code from 127\.0\.0\.1:12355: 404 in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be not ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
-healthcheck: bad status code from 127\.0\.0\.1:12355: 404
+healthcheck: bad status code from 127\.0\.0\.1:12355: 404 in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be not ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned down after 2 failure\(s\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned down after 2 failure\(s\) in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 (?:healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be not ok
@@ -527,14 +527,14 @@ upstream addr: 127.0.0.1:12355
 [alert]
 failed to run healthcheck cycle
 --- error_log
-healthcheck: failed to receive status line from 127.0.0.1:12354: timeout
+healthcheck: failed to receive status line from 127.0.0.1:12354: timeout in upstream foo.com
 --- grep_error_log eval: qr/healthcheck: .*? was checked .*|warn\(\): .*(?=,)|healthcheck: bad status code from .*(?=,)|upgrading peers version to \d+/
 --- grep_error_log_out eval
 qr/^healthcheck: peer 127\.0\.0\.1:12354 was checked to be not ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12354 was checked to be not ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12354 is turned down after 2 failure\(s\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12354 is turned down after 2 failure\(s\) in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 (?:healthcheck: peer 127\.0\.0\.1:12354 was checked to be not ok
@@ -649,9 +649,9 @@ failed to run healthcheck cycle
 --- grep_error_log eval: qr/healthcheck: .*? was checked .*|warn\(\): .*(?=,)|healthcheck: bad status code from .*(?=,)|publishing peers version \d+|upgrading peers version to \d+/
 --- grep_error_log_out eval
 qr/^healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
-healthcheck: bad status code from 127\.0\.0\.1:12355: 403
+healthcheck: bad status code from 127\.0\.0\.1:12355: 403 in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be not ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned down after 1 failure\(s\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned down after 1 failure\(s\) in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 publishing peers version 1
 healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
@@ -662,7 +662,7 @@ healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned up after 2 success\(es\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned up after 2 success\(es\) in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 publishing peers version 2
 (?:healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
@@ -775,9 +775,9 @@ healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned up after 2 success\(es\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12355 is turned up after 2 success\(es\) in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12356 is turned up after 2 success\(es\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12356 is turned up after 2 success\(es\) in upstream foo\.com
 publishing peers version 2
 (?:healthcheck: peer 127\.0\.0\.1:12354 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
@@ -880,7 +880,7 @@ healthcheck: peer 127\.0\.0\.1:12354 was checked to be not ok
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12354 was checked to be not ok
-warn\(\): healthcheck: peer 127\.0\.0\.1:12354 is turned down after 2 failure\(s\)
+warn\(\): healthcheck: peer 127\.0\.0\.1:12354 is turned down after 2 failure\(s\) in upstream foo\.com
 healthcheck: peer 127\.0\.0\.1:12355 was checked to be ok
 healthcheck: peer 127\.0\.0\.1:12356 was checked to be ok
 publishing peers version 2
@@ -1198,8 +1198,8 @@ upstream addr: 127.0.0.1:12354
 [alert]
 failed to run healthcheck cycle
 --- error_log
-healthcheck: bad status code from 127.0.0.1:12355
-healthcheck: bad status code from 127.0.0.1:12357
+healthcheck: bad status code from 127.0.0.1:12355: 404 in upstream foo.com
+healthcheck: bad status code from 127.0.0.1:12355: 404 in upstream bar.com
 --- timeout: 6
 
 


### PR DESCRIPTION
When more than one upstream uses the same server, the health check log messages do not say which upstream they belong to. For example:

```
healthcheck: failed to receive status line from 10.0.0.1:80: timeout
healthcheck: peer 10.0.0.1:80 is turned down after 3 failure(s)
```

There is no way to tell which upstream these are about.

This adds the upstream name to those messages:

```
healthcheck: failed to receive status line from 10.0.0.1:80: timeout in upstream foo.com
healthcheck: peer 10.0.0.1:80 is turned down after 3 failure(s) in upstream foo.com
```

It applies to all the per-peer error messages (connect, ssl handshake, send, receive, bad status line, bad status code) and to the turn-down / turn-up warnings. The debug-only "was checked" lines are left unchanged.

The existing tests still pass (the old text is kept, the name is only added at the end). Several tests are updated to check the new part, including one that shows the same server reported under two different upstreams.

Resolves #70.
Resolves #71.
